### PR TITLE
Auto-init key.id based on controller, if present.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,14 @@
 # x25519-key-pair ChangeLog
 
+## 3.0.0 - TBD
+
+### Added
+- Auto-initialize key.id based on controller (if it's present).
+
+### Changed
+- **BREAKING**: Explicitly make `publicBase58` property required for Ed25519
+  type keys (throw error if missing).
+
 ## 2.0.0 - 2020-03-09
 
 ### Changed

--- a/lib/X25519KeyPair.js
+++ b/lib/X25519KeyPair.js
@@ -28,17 +28,18 @@ export class X25519KeyPair extends LDKeyPair {
    * @param {KeyPairOptions} options - Base58 keys plus other options
    * @param {string} options.controller
    * @param {string} options.id
-   * @param {string} options.publicKeyBase58 - Base58 encoded Public Key
-   * unencoded is 32-bytes.
-   * @param {string} options.privateKeyBase58 - Base58 Private Key
-   * unencoded is 32-bytes.
+   * @param {string} options.publicKeyBase58 - Base58 encoded Public Key.
+   * @param {string} [options.privateKeyBase58] - Base58 Private Key.
    */
   constructor(options = {}) {
     super(options);
     this.type = 'X25519KeyAgreementKey2019';
-    this.privateKeyBase58 = options.privateKeyBase58;
     this.publicKeyBase58 = options.publicKeyBase58;
-    if(this.controller && this.publicKeyBase58 && !this.id) {
+    if(!this.publicKeyBase58) {
+      throw TypeError('The "publicKeyBase58" property is required.');
+    }
+    this.privateKeyBase58 = options.privateKeyBase58;
+    if(this.controller && !this.id) {
       this.id = `${this.controller}#${this.fingerprint()}`;
     }
   }
@@ -112,11 +113,10 @@ export class X25519KeyPair extends LDKeyPair {
 
   static fromEdKeyPair(edKeyPair) {
     const xKey = new X25519KeyPair({
-      controller: edKeyPair.controller
+      controller: edKeyPair.controller,
+      publicKeyBase58: X25519KeyPair
+        .convertFromEdPublicKey(edKeyPair.publicKeyBase58)
     });
-
-    xKey.publicKeyBase58 = X25519KeyPair
-      .convertFromEdPublicKey(edKeyPair.publicKeyBase58);
 
     if(edKeyPair.privateKeyBase58) {
       xKey.privateKeyBase58 = X25519KeyPair

--- a/lib/X25519KeyPair.js
+++ b/lib/X25519KeyPair.js
@@ -38,6 +38,9 @@ export class X25519KeyPair extends LDKeyPair {
     this.type = 'X25519KeyAgreementKey2019';
     this.privateKeyBase58 = options.privateKeyBase58;
     this.publicKeyBase58 = options.publicKeyBase58;
+    if(this.controller && this.publicKeyBase58 && !this.id) {
+      this.id = `${this.controller}#${this.fingerprint()}`;
+    }
   }
   /**
    * Returns the Base58 encoded public key.

--- a/tests/unit/index.js
+++ b/tests/unit/index.js
@@ -26,6 +26,17 @@ describe('X25519KeyPair', () => {
       expect(keyPair.id).to.equal(
         'did:example:1234#z6LSjeJZaUHMvEKW7tEJXV4PrSm61NzxxHhDXF6zHnVtDu9g');
     });
+
+    it('should error if publicKeyBase58 property is missing', async () => {
+      let error;
+      try {
+        new X25519KeyPair({});
+      } catch(e) {
+        error = e;
+      }
+      expect(error.message)
+        .to.equal('The "publicKeyBase58" property is required.');
+    });
   });
 
   describe('fromEdKeyPair', () => {

--- a/tests/unit/index.js
+++ b/tests/unit/index.js
@@ -11,7 +11,23 @@ const {Ed25519KeyPair} = require('crypto-ld');
 const {X25519KeyPair} = require('../../');
 const {util: {binary: {base58}}} = require('node-forge');
 
+const mockKey = {
+  publicKeyBase58: '8y8Q4AUVpmbm2VrXzqYSXrYcAETrFgX4eGPJoKrMWXNv',
+  privateKeyBase58: '95tmYuhqSuJqY77FEg78Zy3LFQ1cENxGv2wMvayk7Lqf'
+};
+
 describe('X25519KeyPair', () => {
+  describe('constructor', () => {
+    it('should auto-set key.id based on controller, if present', async () => {
+      const {publicKeyBase58} = mockKey;
+      const controller = 'did:example:1234';
+
+      const keyPair = new X25519KeyPair({controller, publicKeyBase58});
+      expect(keyPair.id).to.equal(
+        'did:example:1234#z6LSjeJZaUHMvEKW7tEJXV4PrSm61NzxxHhDXF6zHnVtDu9g');
+    });
+  });
+
   describe('fromEdKeyPair', () => {
     it('should convert both public and private key', async () => {
       const edKeyPair = await Ed25519KeyPair.from({


### PR DESCRIPTION
If a `controller` is passed to the LDKeyPair constructor, this PR initializes the key id based on our controller + fingerprint recommendations. (Similar to PR https://github.com/digitalbazaar/crypto-ld/pull/45)